### PR TITLE
To modify the SD driver initialization for the FMU-v2 target board

### DIFF
--- a/target/pixhawk/fmu-v2/drivers/sdio/drv_sdio.c
+++ b/target/pixhawk/fmu-v2/drivers/sdio/drv_sdio.c
@@ -118,7 +118,7 @@ rt_err_t _sd_dev_control(rt_device_t dev, int cmd, void* args)
     return RT_EOK;
 }
 
-rt_err_t drv_sdio_init(const char* device_name)
+rt_err_t drv_sdio_init(void)
 {
     rt_err_t res = RT_EOK;
     ;


### PR DESCRIPTION
To modify the SD driver initialization for the FMU-v2 target board, which previously caused the compilation to use the FMU-v5 driver for initialization.

![1714987750573](https://github.com/Firmament-Autopilot/FMT-Firmware/assets/42925478/c244792d-67b4-4a11-956e-81e651b66d2e)
![1714988103477](https://github.com/Firmament-Autopilot/FMT-Firmware/assets/42925478/e7a6245a-f391-4906-890a-ccb0653cbd3d)

The implementation in target/pixhawk/fmu-v2/drivers/sdio/drv_sdio.c is rt_err_t drv_sdio_init(const char* device_name), but in target/pixhawk/fmu-v2/drivers/sdio/drv_sdio.h and the implementation in board.c, it is declared and implemented as rt_err_t drv_sdio_init(void). This discrepancy leads to the usage of the FMU-v5 SD driver during compilation, utilizing the SD read/write functionalities from the F7 HAL library. It is likely that both FMU-v2 and FMU-v5 share the same register addresses for SD operations.