### PR TITLE
Update MS5611 barometer driver to ensure 100hz update rate

### DIFF
--- a/src/driver/barometer/ms5611.c
+++ b/src/driver/barometer/ms5611.c
@@ -48,7 +48,7 @@
 #define BARO_OSR_2048   3
 #define BARO_OSR_4096   4
 
-#define DEFAULT_OSR     BARO_OSR_2048
+#define DEFAULT_OSR     BARO_OSR_1024
 
 static uint8_t CMD_CONVERT_D1_ADDR[5] = {
     0x40, // OSR=256
@@ -332,7 +332,8 @@ static rt_err_t baro_control(baro_dev_t baro, int cmd, void* arg)
 {
     switch (cmd) {
     case BARO_CMD_CHECK_READY: {
-        *(uint8_t*)arg = _updated;
+        DEFINE_TIMETAG(baro_interval, 10);
+        *(uint8_t*)arg = (_updated && check_timetag(TIMETAG(baro_interval))) ? 1 : 0;
     } break;
 
     default:

--- a/src/module/sensor/sensor_hub.c
+++ b/src/module/sensor/sensor_hub.c
@@ -821,7 +821,7 @@ void sensor_collect(void)
     if (check_timetag(TIMETAG(airspeed_interval))) {
         if (airspeed_dev != NULL) {
             if (sensor_airspeed_measure(airspeed_dev, &airspeed_data) == FMT_EOK) {
-                /* publish barometer data */
+                /* publish airspeed data */
                 mcn_publish(MCN_HUB(sensor_airspeed), &airspeed_data);
             }
         }


### PR DESCRIPTION
原先的ms5611驱动虽然配置的是100hz，但是没有更新频率调度，实际运行时消息大约在83hz左右。
更新的驱动按照spl06和bmp581类似的方式，采样频率略高于100hz，控制发布频率在100hz。经测试可以稳定保持100hz发布