### PR TITLE
QGC calibration update

### DIFF
--- a/src/module/mavproxy/mavproxy_cmd.c
+++ b/src/module/mavproxy/mavproxy_cmd.c
@@ -38,7 +38,7 @@ MCN_DECLARE(ins_output);
 #define LEVEL_CALIBRATE_COUNT 200
 #define ACC_MAX_THRESHOLD     8.8f
 #define ACC_MIN_THRESHOLD     2.0f
-#define GYR_ROTAT_THRESHOLD   1.0f
+#define GYR_ROTAT_THRESHOLD   0.5f
 #define CALIB_TIME_INTERVAL   20
 
 typedef enum {
@@ -59,7 +59,7 @@ typedef struct {
 } MAVCMD_CALIB_GYR;
 
 typedef struct {
-    uint8_t status; //0:start 1:calibrating 2:finish
+    uint8_t status; // 0:start 1:calibrating 2:finish
     uint8_t done_flag[6];
     uint32_t cnt[6];
     acc_position acc_pos;
@@ -753,7 +753,7 @@ static void level_calibration(void)
             PARAM_SET_FLOAT(CALIB, LEVEL_YOFF, mavcmd_calib_level.board_pitch_off);
 
             mavlink_send_statustext(MAVLINK_STATUS_INFO, CAL_QGC_DONE_MSG, "level");
-            //console_printf("Update Level Horizontal Offset: [%f %f]\n", mavcmd_calib_level.board_roll_off, mavcmd_calib_level.board_pitch_off);
+            // console_printf("Update Level Horizontal Offset: [%f %f]\n", mavcmd_calib_level.board_roll_off, mavcmd_calib_level.board_pitch_off);
 
             level_calibration_reset();
         }

--- a/src/task/comm/mavgcs.c
+++ b/src/task/comm/mavgcs.c
@@ -91,7 +91,7 @@ static void handle_mavlink_command(mavlink_command_long_t* command, mavlink_mess
     } break;
 
     case MAV_CMD_PREFLIGHT_CALIBRATION:
-        if (command->param1 == 1) {        // calibration gyr
+        if (command->param1 == 1) { // calibration gyr
             mavproxy_cmd_set(MAVCMD_CALIBRATION_GYR, NULL);
         } else if (command->param2 == 1) { // calibration mag
             mavproxy_cmd_set(MAVCMD_CALIBRATION_MAG, NULL);
@@ -101,6 +101,11 @@ static void handle_mavlink_command(mavlink_command_long_t* command, mavlink_mess
             mavproxy_cmd_set(MAVCMD_CALIBRATION_LEVEL, NULL);
         } else {
             /* all 0 command, cancel current process */
+            mavproxy_cmd_reset(MAVCMD_CALIBRATION_GYR);
+            mavproxy_cmd_reset(MAVCMD_CALIBRATION_ACC);
+            mavproxy_cmd_reset(MAVCMD_CALIBRATION_MAG);
+            mavproxy_cmd_reset(MAVCMD_CALIBRATION_LEVEL);
+            mavlink_send_statustext(MAVLINK_STATUS_INFO, CAL_QGC_CANCELLED_MSG);
         }
 
         mavlink_command_acknowledge(MAVPROXY_GCS_CHAN, command->command, MAV_RESULT_ACCEPTED);


### PR DESCRIPTION
1.fix QGC stuck when cancel calibration. 
2.change GYR_ROTAT_THRESHOLD from 1 rad/s to 0.5 rad/s to easily enter mag cal.