### PR TITLE
fix airspeed device type from I2C bus to I2C device

### DIFF
--- a/src/hal/airspeed/airspeed.c
+++ b/src/hal/airspeed/airspeed.c
@@ -55,7 +55,7 @@ static rt_err_t hal_airspeed_control(struct rt_device* dev,
 
 /**
  * @brief register an airspeed device
- * 
+ *
  * @param dev airspeed device
  * @param name device name
  * @param flag device flag

--- a/src/hal/airspeed/airspeed.c
+++ b/src/hal/airspeed/airspeed.c
@@ -71,7 +71,7 @@ rt_err_t hal_airspeed_register(airspeed_dev_t dev, const char* name, rt_uint32_t
 
     device = &(dev->parent);
 
-    device->type = (dev->bus_type == AIRSPEED_SPI_BUS_TYPE) ? RT_Device_Class_SPIDevice : RT_Device_Class_I2CBUS;
+    device->type = (dev->bus_type == AIRSPEED_SPI_BUS_TYPE) ? RT_Device_Class_SPIDevice : RT_Device_Class_I2CDevice;
     device->ref_count = 0;
     device->rx_indicate = RT_NULL;
     device->tx_complete = RT_NULL;


### PR DESCRIPTION
<img width="983" height="1032" alt="image" src="https://github.com/user-attachments/assets/d2202029-bd56-4adb-a60a-a2ea2f7273d6" />
