### PR TITLE
Increase IO baudrate to 921600

### DIFF
--- a/target/cuav/7_nano/drivers/drv_usart.c
+++ b/target/cuav/7_nano/drivers/drv_usart.c
@@ -23,28 +23,28 @@
 #define UART_DISABLE_IRQ(n) NVIC_DisableIRQ((n))
 
 /* config for serial_configure structure */
-#define SERIAL3_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_9600,      /* 9600 bits/s */    \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL3_DEFAULT_CONFIG                \
+    {                                         \
+        BAUD_RATE_9600,  /* 9600 bits/s */    \
+        DATA_BITS_8,     /* 8 databits */     \
+        STOP_BITS_1,     /* 1 stopbit */      \
+        PARITY_NONE,     /* No parity  */     \
+        BIT_ORDER_LSB,   /* LSB first sent */ \
+        NRZ_NORMAL,      /* Normal mode */    \
+        SERIAL_RB_BUFSZ, /* Buffer size */    \
+        0                                     \
     }
 
-#define SERIAL5_DEFAULT_CONFIG                  \
-    {                                           \
-        BAUD_RATE_230400,  /* 115200 bits/s */  \
-            DATA_BITS_8,   /* 8 databits */     \
-            STOP_BITS_1,   /* 1 stopbit */      \
-            PARITY_NONE,   /* No parity  */     \
-            BIT_ORDER_LSB, /* LSB first sent */ \
-            NRZ_NORMAL,    /* Normal mode */    \
-            1024,          /* Buffer size */    \
-            0                                   \
+#define SERIAL5_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_921600, /* 921600 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        1024,             /* Buffer size */    \
+        0                                      \
     }
 
 /* STM32 uart driver */

--- a/target/cuav/v5_nano/drivers/drv_usart.c
+++ b/target/cuav/v5_nano/drivers/drv_usart.c
@@ -39,46 +39,46 @@
 #define USING_UART8
 
 /* config for serial_configure structure */
-#define SERIAL3_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_38400,      /* 9600 bits/s */    \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL3_DEFAULT_CONFIG                \
+    {                                         \
+        BAUD_RATE_38400, /* 9600 bits/s */    \
+        DATA_BITS_8,     /* 8 databits */     \
+        STOP_BITS_1,     /* 1 stopbit */      \
+        PARITY_NONE,     /* No parity  */     \
+        BIT_ORDER_LSB,   /* LSB first sent */ \
+        NRZ_NORMAL,      /* Normal mode */    \
+        SERIAL_RB_BUFSZ, /* Buffer size */    \
+        0                                     \
     }
 
-#define SERIAL4_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_115200,    /* 115200 bits/s */  \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL4_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_115200, /* 115200 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        SERIAL_RB_BUFSZ,  /* Buffer size */    \
+        0                                      \
     }
 
-#define SERIAL5_DEFAULT_CONFIG                  \
-    {                                           \
-        BAUD_RATE_230400,  /* 230400 bits/s */  \
-            DATA_BITS_8,   /* 8 databits */     \
-            STOP_BITS_1,   /* 1 stopbit */      \
-            PARITY_NONE,   /* No parity  */     \
-            BIT_ORDER_LSB, /* LSB first sent */ \
-            NRZ_NORMAL,    /* Normal mode */    \
-            1024,          /* Buffer size */    \
-            0                                   \
+#define SERIAL5_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_921600, /* 921600 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        1024,             /* Buffer size */    \
+        0                                      \
     }
 
 /* STM32 uart driver */
 struct stm32_uart {
     USART_TypeDef* uart_device;
-    IRQn_Type      irq;
+    IRQn_Type irq;
     struct stm32_uart_dma {
         /* dma instance */
         DMA_TypeDef* dma_device;
@@ -102,10 +102,10 @@ struct stm32_uart {
 };
 
 static rt_size_t usart_dma_transmit(struct serial_device* serial, rt_uint8_t* buf, rt_size_t size, int direction);
-static int       usart_getc(struct serial_device* serial);
-static int       usart_putc(struct serial_device* serial, char c);
-static rt_err_t  usart_control(struct serial_device* serial, int cmd, void* arg);
-static rt_err_t  usart_configure(struct serial_device* serial, struct serial_configure* cfg);
+static int usart_getc(struct serial_device* serial);
+static int usart_putc(struct serial_device* serial, char c);
+static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg);
+static rt_err_t usart_configure(struct serial_device* serial, struct serial_configure* cfg);
 
 static void _dma_clear_flags(DMA_TypeDef* dma, uint32_t stream)
 {
@@ -127,9 +127,9 @@ static void _dma_clear_flags(DMA_TypeDef* dma, uint32_t stream)
 static void dma_uart_rx_idle_isr(struct serial_device* serial)
 {
     struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
-    rt_size_t          recv_total_index, recv_len;
-    rt_base_t          level;
-    uint32_t           remain_bytes;
+    rt_size_t recv_total_index, recv_len;
+    rt_base_t level;
+    uint32_t remain_bytes;
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -158,8 +158,8 @@ static void dma_uart_rx_idle_isr(struct serial_device* serial)
 static void dma_rx_done_isr(struct serial_device* serial)
 {
     struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
-    rt_size_t          recv_len;
-    rt_base_t          level;
+    rt_size_t recv_len;
+    rt_base_t level;
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -234,17 +234,17 @@ static struct serial_device serial3; // GPS
 /* UART2 device driver structure */
 struct stm32_uart uart1 = {
     .uart_device = USART1,
-    .irq         = USART1_IRQn,
-    .dma         = {
-                .dma_device       = DMA2,
-                .rx_stream        = LL_DMA_STREAM_2,
-                .rx_ch            = LL_DMA_CHANNEL_4,
-                .rx_irq           = DMA2_Stream2_IRQn,
-                .tx_stream        = LL_DMA_STREAM_7,
-                .tx_ch            = LL_DMA_CHANNEL_4,
-                .tx_irq           = DMA2_Stream7_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = USART1_IRQn,
+    .dma = {
+        .dma_device = DMA2,
+        .rx_stream = LL_DMA_STREAM_2,
+        .rx_ch = LL_DMA_CHANNEL_4,
+        .rx_irq = DMA2_Stream2_IRQn,
+        .tx_stream = LL_DMA_STREAM_7,
+        .tx_ch = LL_DMA_CHANNEL_4,
+        .tx_irq = DMA2_Stream7_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -294,8 +294,8 @@ static struct serial_device serial1; // TELEM1
 /* UART2 device driver structure */
 struct stm32_uart uart2 = {
     .uart_device = USART2,
-    .irq         = USART2_IRQn,
-    .dma         = { 0 }
+    .irq = USART2_IRQn,
+    .dma = { 0 }
 };
 
 void USART2_IRQHandler(void)
@@ -315,17 +315,17 @@ static struct serial_device serial2; // TELEM2
 /* UART3 device driver structure */
 struct stm32_uart uart3 = {
     .uart_device = USART3,
-    .irq         = USART3_IRQn,
-    .dma         = {
-                .dma_device       = DMA1,
-                .rx_stream        = LL_DMA_STREAM_1,
-                .rx_ch            = LL_DMA_CHANNEL_4,
-                .rx_irq           = DMA1_Stream1_IRQn,
-                .tx_stream        = LL_DMA_STREAM_3,
-                .tx_ch            = LL_DMA_CHANNEL_4,
-                .tx_irq           = DMA1_Stream3_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = USART3_IRQn,
+    .dma = {
+        .dma_device = DMA1,
+        .rx_stream = LL_DMA_STREAM_1,
+        .rx_ch = LL_DMA_CHANNEL_4,
+        .rx_irq = DMA1_Stream1_IRQn,
+        .tx_stream = LL_DMA_STREAM_3,
+        .tx_ch = LL_DMA_CHANNEL_4,
+        .tx_irq = DMA1_Stream3_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -376,7 +376,7 @@ static struct serial_device serial4; // UART4
 /* UART2 device driver structure */
 static struct stm32_uart uart4 = {
     .uart_device = UART4,
-    .irq         = UART4_IRQn,
+    .irq = UART4_IRQn,
 };
 
 void UART4_IRQHandler(void)
@@ -396,8 +396,8 @@ static struct serial_device serial0; // FMU Debug
 /* UART7 device driver structure */
 struct stm32_uart uart7 = {
     .uart_device = UART7,
-    .irq         = UART7_IRQn,
-    .dma         = { 0 }
+    .irq = UART7_IRQn,
+    .dma = { 0 }
 };
 
 void UART7_IRQHandler(void)
@@ -417,17 +417,17 @@ static struct serial_device serial5; // FMTIO
 /* UART7 device driver structure */
 struct stm32_uart uart8 = {
     .uart_device = UART8,
-    .irq         = UART8_IRQn,
-    .dma         = {
-                .dma_device       = DMA1,
-                .rx_stream        = LL_DMA_STREAM_6,
-                .rx_ch            = LL_DMA_CHANNEL_5,
-                .rx_irq           = DMA1_Stream6_IRQn,
-                .tx_stream        = LL_DMA_STREAM_0,
-                .tx_ch            = LL_DMA_CHANNEL_5,
-                .tx_irq           = DMA1_Stream0_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = UART8_IRQn,
+    .dma = {
+        .dma_device = DMA1,
+        .rx_stream = LL_DMA_STREAM_6,
+        .rx_ch = LL_DMA_CHANNEL_5,
+        .rx_irq = DMA1_Stream6_IRQn,
+        .tx_stream = LL_DMA_STREAM_0,
+        .tx_ch = LL_DMA_CHANNEL_5,
+        .tx_irq = DMA1_Stream0_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -514,67 +514,67 @@ static void GPIO_Configuration(void)
 {
     LL_GPIO_InitTypeDef GPIO_InitStruct = { 0 };
 
-    GPIO_InitStruct.Mode       = LL_GPIO_MODE_ALTERNATE;
-    GPIO_InitStruct.Speed      = LL_GPIO_SPEED_FREQ_VERY_HIGH;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_ALTERNATE;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-    GPIO_InitStruct.Pull       = LL_GPIO_PULL_UP;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_UP;
 
 #ifdef USING_UART1
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_7;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_7;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 #endif /* USING_UART1 */
 
 #ifdef USING_UART2
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_5;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_5;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART2 */
 
 #ifdef USING_UART3
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_9;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_9;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_8;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_8;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART3 */
 
 #ifdef USING_UART4
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_0;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_0;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_1;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_1;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART4 */
 
 #ifdef USING_UART7
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOF, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_8;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_8;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 #endif /* USING_UART7 */
 
 #ifdef USING_UART8
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_1;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_1;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_0;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_0;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 #endif /* USING_UART8 */
@@ -650,21 +650,21 @@ static void _dma_rx_config(struct stm32_uart* uart, rt_uint8_t* buf, rt_size_t s
     /* set expected receive length */
     uart->dma.setting_recv_len = size;
 
-    DMA_InitStruct.PeriphOrM2MSrcAddress  = (uint32_t)&uart->uart_device->RDR;
-    DMA_InitStruct.MemoryOrM2MDstAddress  = (uint32_t)buf;
-    DMA_InitStruct.Direction              = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
-    DMA_InitStruct.Mode                   = LL_DMA_MODE_CIRCULAR;
-    DMA_InitStruct.PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
-    DMA_InitStruct.MemoryOrM2MDstIncMode  = LL_DMA_MEMORY_INCREMENT;
+    DMA_InitStruct.PeriphOrM2MSrcAddress = (uint32_t)&uart->uart_device->RDR;
+    DMA_InitStruct.MemoryOrM2MDstAddress = (uint32_t)buf;
+    DMA_InitStruct.Direction = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
+    DMA_InitStruct.Mode = LL_DMA_MODE_CIRCULAR;
+    DMA_InitStruct.PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+    DMA_InitStruct.MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
     DMA_InitStruct.PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
     DMA_InitStruct.MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
-    DMA_InitStruct.NbData                 = size;
-    DMA_InitStruct.Channel                = uart->dma.rx_ch;
-    DMA_InitStruct.Priority               = LL_DMA_PRIORITY_HIGH;
-    DMA_InitStruct.FIFOMode               = LL_DMA_FIFOMODE_DISABLE;
-    DMA_InitStruct.FIFOThreshold          = LL_DMA_FIFOTHRESHOLD_1_4;
-    DMA_InitStruct.MemBurst               = LL_DMA_MBURST_SINGLE;
-    DMA_InitStruct.PeriphBurst            = LL_DMA_PBURST_SINGLE;
+    DMA_InitStruct.NbData = size;
+    DMA_InitStruct.Channel = uart->dma.rx_ch;
+    DMA_InitStruct.Priority = LL_DMA_PRIORITY_HIGH;
+    DMA_InitStruct.FIFOMode = LL_DMA_FIFOMODE_DISABLE;
+    DMA_InitStruct.FIFOThreshold = LL_DMA_FIFOTHRESHOLD_1_4;
+    DMA_InitStruct.MemBurst = LL_DMA_MBURST_SINGLE;
+    DMA_InitStruct.PeriphBurst = LL_DMA_PBURST_SINGLE;
     /* init rx dma */
     LL_DMA_Init(uart->dma.dma_device, uart->dma.rx_stream, &DMA_InitStruct);
 
@@ -680,21 +680,21 @@ static void _dma_tx_config(struct stm32_uart* uart)
 {
     LL_DMA_InitTypeDef DMA_InitStruct;
 
-    DMA_InitStruct.PeriphOrM2MSrcAddress  = (uint32_t)&uart->uart_device->TDR;
-    DMA_InitStruct.MemoryOrM2MDstAddress  = 0x00000000U; /* will be configured later */
-    DMA_InitStruct.Direction              = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
-    DMA_InitStruct.Mode                   = LL_DMA_MODE_NORMAL;
-    DMA_InitStruct.PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
-    DMA_InitStruct.MemoryOrM2MDstIncMode  = LL_DMA_MEMORY_INCREMENT;
+    DMA_InitStruct.PeriphOrM2MSrcAddress = (uint32_t)&uart->uart_device->TDR;
+    DMA_InitStruct.MemoryOrM2MDstAddress = 0x00000000U; /* will be configured later */
+    DMA_InitStruct.Direction = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
+    DMA_InitStruct.Mode = LL_DMA_MODE_NORMAL;
+    DMA_InitStruct.PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+    DMA_InitStruct.MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
     DMA_InitStruct.PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
     DMA_InitStruct.MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
-    DMA_InitStruct.NbData                 = 0x00000000U; /* will be configured later */
-    DMA_InitStruct.Channel                = uart->dma.tx_ch;
-    DMA_InitStruct.Priority               = LL_DMA_PRIORITY_HIGH;
-    DMA_InitStruct.FIFOMode               = LL_DMA_FIFOMODE_DISABLE;
-    DMA_InitStruct.FIFOThreshold          = LL_DMA_FIFOTHRESHOLD_1_4;
-    DMA_InitStruct.MemBurst               = LL_DMA_MBURST_SINGLE;
-    DMA_InitStruct.PeriphBurst            = LL_DMA_PBURST_SINGLE;
+    DMA_InitStruct.NbData = 0x00000000U; /* will be configured later */
+    DMA_InitStruct.Channel = uart->dma.tx_ch;
+    DMA_InitStruct.Priority = LL_DMA_PRIORITY_HIGH;
+    DMA_InitStruct.FIFOMode = LL_DMA_FIFOMODE_DISABLE;
+    DMA_InitStruct.FIFOThreshold = LL_DMA_FIFOTHRESHOLD_1_4;
+    DMA_InitStruct.MemBurst = LL_DMA_MBURST_SINGLE;
+    DMA_InitStruct.PeriphBurst = LL_DMA_PBURST_SINGLE;
     /* init tx dma */
     LL_DMA_Init(uart->dma.dma_device, uart->dma.tx_stream, &DMA_InitStruct);
 
@@ -732,7 +732,7 @@ static void _close_usart(struct serial_device* serial)
 
 static rt_err_t usart_configure(struct serial_device* serial, struct serial_configure* cfg)
 {
-    struct stm32_uart*   uart;
+    struct stm32_uart* uart;
     LL_USART_InitTypeDef USART_InitStructure = { 0 };
 
     RT_ASSERT(serial != RT_NULL);
@@ -763,8 +763,8 @@ static rt_err_t usart_configure(struct serial_device* serial, struct serial_conf
     }
     // TODO: Add hw flow control
     USART_InitStructure.HardwareFlowControl = LL_USART_HWCONTROL_NONE;
-    USART_InitStructure.TransferDirection   = LL_USART_DIRECTION_TX_RX;
-    USART_InitStructure.OverSampling        = LL_USART_OVERSAMPLING_16;
+    USART_InitStructure.TransferDirection = LL_USART_DIRECTION_TX_RX;
+    USART_InitStructure.OverSampling = LL_USART_OVERSAMPLING_16;
 
     /* USART need be disabled first in order to configure it */
     LL_USART_Disable(uart->uart_device);
@@ -779,7 +779,7 @@ static rt_err_t usart_configure(struct serial_device* serial, struct serial_conf
 static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg)
 {
     struct stm32_uart* uart;
-    rt_uint32_t        ctrl_arg = (rt_uint32_t)(arg);
+    rt_uint32_t ctrl_arg = (rt_uint32_t)(arg);
 
     RT_ASSERT(serial != RT_NULL);
     uart = (struct stm32_uart*)serial->parent.user_data;
@@ -807,7 +807,7 @@ static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg)
     case RT_DEVICE_CTRL_CONFIG:
         if (ctrl_arg == RT_DEVICE_FLAG_DMA_RX) {
             struct serial_rx_fifo* rx_fifo = (struct serial_rx_fifo*)serial->serial_rx;
-            struct stm32_uart*     uart    = (struct stm32_uart*)serial->parent.user_data;
+            struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
 
             if (LL_DMA_IsEnabledStream(uart->dma.dma_device, uart->dma.rx_stream)) {
                 /* dma is busy */
@@ -859,7 +859,7 @@ static int usart_putc(struct serial_device* serial, char c)
 
 static int usart_getc(struct serial_device* serial)
 {
-    int                ch = -1;
+    int ch = -1;
     struct stm32_uart* uart;
 
     RT_ASSERT(serial != RT_NULL);
@@ -895,7 +895,7 @@ static const struct usart_ops _usart_ops = {
 
 rt_err_t drv_usart_init(void)
 {
-    rt_err_t                rt_err = RT_EOK;
+    rt_err_t rt_err = RT_EOK;
     struct serial_configure config = SERIAL_DEFAULT_CONFIG;
 
     RCC_Configuration();
@@ -905,7 +905,7 @@ rt_err_t drv_usart_init(void)
     serial0.ops = &_usart_ops;
     #ifdef SERIAL0_DEFAULT_CONFIG
     struct serial_configure serial0_config = SERIAL0_DEFAULT_CONFIG;
-    serial0.config                         = serial0_config;
+    serial0.config = serial0_config;
     #else
     serial0.config = config;
     #endif
@@ -922,7 +922,7 @@ rt_err_t drv_usart_init(void)
     serial1.ops = &_usart_ops;
     #ifdef SERIAL1_DEFAULT_CONFIG
     struct serial_configure serial1_config = SERIAL1_DEFAULT_CONFIG;
-    serial1.config                         = serial1_config;
+    serial1.config = serial1_config;
     #else
     serial1.config = config;
     #endif
@@ -939,7 +939,7 @@ rt_err_t drv_usart_init(void)
     serial2.ops = &_usart_ops;
     #ifdef SERIAL2_DEFAULT_CONFIG
     struct serial_configure serial2_config = SERIAL2_DEFAULT_CONFIG;
-    serial2.config                         = serial2_config;
+    serial2.config = serial2_config;
     #else
     serial2.config = config;
     #endif
@@ -956,7 +956,7 @@ rt_err_t drv_usart_init(void)
     serial3.ops = &_usart_ops;
     #ifdef SERIAL3_DEFAULT_CONFIG
     struct serial_configure serial3_config = SERIAL3_DEFAULT_CONFIG;
-    serial3.config                         = serial3_config;
+    serial3.config = serial3_config;
     #else
     serial3.config = config;
     #endif
@@ -973,7 +973,7 @@ rt_err_t drv_usart_init(void)
     serial4.ops = &_usart_ops;
     #ifdef SERIAL4_DEFAULT_CONFIG
     struct serial_configure serial4_config = SERIAL4_DEFAULT_CONFIG;
-    serial4.config                         = serial4_config;
+    serial4.config = serial4_config;
     #else
     serial4.config = config;
     #endif
@@ -990,7 +990,7 @@ rt_err_t drv_usart_init(void)
     serial5.ops = &_usart_ops;
     #ifdef SERIAL5_DEFAULT_CONFIG
     struct serial_configure serial5_config = SERIAL5_DEFAULT_CONFIG;
-    serial5.config                         = serial5_config;
+    serial5.config = serial5_config;
     #else
     serial5.config = config;
     #endif

--- a/target/minimum/cuav/v5_plus/drivers/drv_usart.c
+++ b/target/minimum/cuav/v5_plus/drivers/drv_usart.c
@@ -39,46 +39,46 @@
 #define USING_UART8
 
 /* config for serial_configure structure */
-#define SERIAL3_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_9600,      /* 9600 bits/s */    \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL3_DEFAULT_CONFIG                \
+    {                                         \
+        BAUD_RATE_9600,  /* 9600 bits/s */    \
+        DATA_BITS_8,     /* 8 databits */     \
+        STOP_BITS_1,     /* 1 stopbit */      \
+        PARITY_NONE,     /* No parity  */     \
+        BIT_ORDER_LSB,   /* LSB first sent */ \
+        NRZ_NORMAL,      /* Normal mode */    \
+        SERIAL_RB_BUFSZ, /* Buffer size */    \
+        0                                     \
     }
 
-#define SERIAL4_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_115200,    /* 115200 bits/s */  \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL4_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_115200, /* 115200 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        SERIAL_RB_BUFSZ,  /* Buffer size */    \
+        0                                      \
     }
 
-#define SERIAL5_DEFAULT_CONFIG                  \
-    {                                           \
-        BAUD_RATE_230400,  /* 230400 bits/s */  \
-            DATA_BITS_8,   /* 8 databits */     \
-            STOP_BITS_1,   /* 1 stopbit */      \
-            PARITY_NONE,   /* No parity  */     \
-            BIT_ORDER_LSB, /* LSB first sent */ \
-            NRZ_NORMAL,    /* Normal mode */    \
-            1024,          /* Buffer size */    \
-            0                                   \
+#define SERIAL5_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_921600, /* 921600 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        1024,             /* Buffer size */    \
+        0                                      \
     }
 
 /* STM32 uart driver */
 struct stm32_uart {
     USART_TypeDef* uart_device;
-    IRQn_Type      irq;
+    IRQn_Type irq;
     struct stm32_uart_dma {
         /* dma instance */
         DMA_TypeDef* dma_device;
@@ -102,10 +102,10 @@ struct stm32_uart {
 };
 
 static rt_size_t usart_dma_transmit(struct serial_device* serial, rt_uint8_t* buf, rt_size_t size, int direction);
-static int       usart_getc(struct serial_device* serial);
-static int       usart_putc(struct serial_device* serial, char c);
-static rt_err_t  usart_control(struct serial_device* serial, int cmd, void* arg);
-static rt_err_t  usart_configure(struct serial_device* serial, struct serial_configure* cfg);
+static int usart_getc(struct serial_device* serial);
+static int usart_putc(struct serial_device* serial, char c);
+static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg);
+static rt_err_t usart_configure(struct serial_device* serial, struct serial_configure* cfg);
 
 static void _dma_clear_flags(DMA_TypeDef* dma, uint32_t stream)
 {
@@ -127,9 +127,9 @@ static void _dma_clear_flags(DMA_TypeDef* dma, uint32_t stream)
 static void dma_uart_rx_idle_isr(struct serial_device* serial)
 {
     struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
-    rt_size_t          recv_total_index, recv_len;
-    rt_base_t          level;
-    uint32_t           remain_bytes;
+    rt_size_t recv_total_index, recv_len;
+    rt_base_t level;
+    uint32_t remain_bytes;
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -158,8 +158,8 @@ static void dma_uart_rx_idle_isr(struct serial_device* serial)
 static void dma_rx_done_isr(struct serial_device* serial)
 {
     struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
-    rt_size_t          recv_len;
-    rt_base_t          level;
+    rt_size_t recv_len;
+    rt_base_t level;
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -234,17 +234,17 @@ static struct serial_device serial3; // GPS
 /* UART2 device driver structure */
 struct stm32_uart uart1 = {
     .uart_device = USART1,
-    .irq         = USART1_IRQn,
-    .dma         = {
-                .dma_device       = DMA2,
-                .rx_stream        = LL_DMA_STREAM_2,
-                .rx_ch            = LL_DMA_CHANNEL_4,
-                .rx_irq           = DMA2_Stream2_IRQn,
-                .tx_stream        = LL_DMA_STREAM_7,
-                .tx_ch            = LL_DMA_CHANNEL_4,
-                .tx_irq           = DMA2_Stream7_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = USART1_IRQn,
+    .dma = {
+        .dma_device = DMA2,
+        .rx_stream = LL_DMA_STREAM_2,
+        .rx_ch = LL_DMA_CHANNEL_4,
+        .rx_irq = DMA2_Stream2_IRQn,
+        .tx_stream = LL_DMA_STREAM_7,
+        .tx_ch = LL_DMA_CHANNEL_4,
+        .tx_irq = DMA2_Stream7_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -294,8 +294,8 @@ static struct serial_device serial1; // TELEM1
 /* UART2 device driver structure */
 struct stm32_uart uart2 = {
     .uart_device = USART2,
-    .irq         = USART2_IRQn,
-    .dma         = { 0 }
+    .irq = USART2_IRQn,
+    .dma = { 0 }
 };
 
 void USART2_IRQHandler(void)
@@ -315,17 +315,17 @@ static struct serial_device serial2; // TELEM2
 /* UART3 device driver structure */
 struct stm32_uart uart3 = {
     .uart_device = USART3,
-    .irq         = USART3_IRQn,
-    .dma         = {
-                .dma_device       = DMA1,
-                .rx_stream        = LL_DMA_STREAM_1,
-                .rx_ch            = LL_DMA_CHANNEL_4,
-                .rx_irq           = DMA1_Stream1_IRQn,
-                .tx_stream        = LL_DMA_STREAM_3,
-                .tx_ch            = LL_DMA_CHANNEL_4,
-                .tx_irq           = DMA1_Stream3_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = USART3_IRQn,
+    .dma = {
+        .dma_device = DMA1,
+        .rx_stream = LL_DMA_STREAM_1,
+        .rx_ch = LL_DMA_CHANNEL_4,
+        .rx_irq = DMA1_Stream1_IRQn,
+        .tx_stream = LL_DMA_STREAM_3,
+        .tx_ch = LL_DMA_CHANNEL_4,
+        .tx_irq = DMA1_Stream3_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -376,7 +376,7 @@ static struct serial_device serial4; // UART4
 /* UART2 device driver structure */
 static struct stm32_uart uart4 = {
     .uart_device = UART4,
-    .irq         = UART4_IRQn,
+    .irq = UART4_IRQn,
 };
 
 void UART4_IRQHandler(void)
@@ -396,8 +396,8 @@ static struct serial_device serial0; // FMU Debug
 /* UART7 device driver structure */
 struct stm32_uart uart7 = {
     .uart_device = UART7,
-    .irq         = UART7_IRQn,
-    .dma         = { 0 }
+    .irq = UART7_IRQn,
+    .dma = { 0 }
 };
 
 void UART7_IRQHandler(void)
@@ -417,17 +417,17 @@ static struct serial_device serial5; // FMTIO
 /* UART7 device driver structure */
 struct stm32_uart uart8 = {
     .uart_device = UART8,
-    .irq         = UART8_IRQn,
-    .dma         = {
-                .dma_device       = DMA1,
-                .rx_stream        = LL_DMA_STREAM_6,
-                .rx_ch            = LL_DMA_CHANNEL_5,
-                .rx_irq           = DMA1_Stream6_IRQn,
-                .tx_stream        = LL_DMA_STREAM_0,
-                .tx_ch            = LL_DMA_CHANNEL_5,
-                .tx_irq           = DMA1_Stream0_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = UART8_IRQn,
+    .dma = {
+        .dma_device = DMA1,
+        .rx_stream = LL_DMA_STREAM_6,
+        .rx_ch = LL_DMA_CHANNEL_5,
+        .rx_irq = DMA1_Stream6_IRQn,
+        .tx_stream = LL_DMA_STREAM_0,
+        .tx_ch = LL_DMA_CHANNEL_5,
+        .tx_irq = DMA1_Stream0_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -514,67 +514,67 @@ static void GPIO_Configuration(void)
 {
     LL_GPIO_InitTypeDef GPIO_InitStruct = { 0 };
 
-    GPIO_InitStruct.Mode       = LL_GPIO_MODE_ALTERNATE;
-    GPIO_InitStruct.Speed      = LL_GPIO_SPEED_FREQ_VERY_HIGH;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_ALTERNATE;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-    GPIO_InitStruct.Pull       = LL_GPIO_PULL_UP;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_UP;
 
 #ifdef USING_UART1
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_7;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_7;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 #endif /* USING_UART1 */
 
 #ifdef USING_UART2
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_5;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_5;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART2 */
 
 #ifdef USING_UART3
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_9;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_9;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_8;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_8;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART3 */
 
 #ifdef USING_UART4
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_0;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_0;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_1;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_1;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART4 */
 
 #ifdef USING_UART7
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOF, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_8;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_8;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 #endif /* USING_UART7 */
 
 #ifdef USING_UART8
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_1;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_1;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_0;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_0;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 #endif /* USING_UART8 */
@@ -650,21 +650,21 @@ static void _dma_rx_config(struct stm32_uart* uart, rt_uint8_t* buf, rt_size_t s
     /* set expected receive length */
     uart->dma.setting_recv_len = size;
 
-    DMA_InitStruct.PeriphOrM2MSrcAddress  = (uint32_t)&uart->uart_device->RDR;
-    DMA_InitStruct.MemoryOrM2MDstAddress  = (uint32_t)buf;
-    DMA_InitStruct.Direction              = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
-    DMA_InitStruct.Mode                   = LL_DMA_MODE_CIRCULAR;
-    DMA_InitStruct.PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
-    DMA_InitStruct.MemoryOrM2MDstIncMode  = LL_DMA_MEMORY_INCREMENT;
+    DMA_InitStruct.PeriphOrM2MSrcAddress = (uint32_t)&uart->uart_device->RDR;
+    DMA_InitStruct.MemoryOrM2MDstAddress = (uint32_t)buf;
+    DMA_InitStruct.Direction = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
+    DMA_InitStruct.Mode = LL_DMA_MODE_CIRCULAR;
+    DMA_InitStruct.PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+    DMA_InitStruct.MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
     DMA_InitStruct.PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
     DMA_InitStruct.MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
-    DMA_InitStruct.NbData                 = size;
-    DMA_InitStruct.Channel                = uart->dma.rx_ch;
-    DMA_InitStruct.Priority               = LL_DMA_PRIORITY_HIGH;
-    DMA_InitStruct.FIFOMode               = LL_DMA_FIFOMODE_DISABLE;
-    DMA_InitStruct.FIFOThreshold          = LL_DMA_FIFOTHRESHOLD_1_4;
-    DMA_InitStruct.MemBurst               = LL_DMA_MBURST_SINGLE;
-    DMA_InitStruct.PeriphBurst            = LL_DMA_PBURST_SINGLE;
+    DMA_InitStruct.NbData = size;
+    DMA_InitStruct.Channel = uart->dma.rx_ch;
+    DMA_InitStruct.Priority = LL_DMA_PRIORITY_HIGH;
+    DMA_InitStruct.FIFOMode = LL_DMA_FIFOMODE_DISABLE;
+    DMA_InitStruct.FIFOThreshold = LL_DMA_FIFOTHRESHOLD_1_4;
+    DMA_InitStruct.MemBurst = LL_DMA_MBURST_SINGLE;
+    DMA_InitStruct.PeriphBurst = LL_DMA_PBURST_SINGLE;
     /* init rx dma */
     LL_DMA_Init(uart->dma.dma_device, uart->dma.rx_stream, &DMA_InitStruct);
 
@@ -680,21 +680,21 @@ static void _dma_tx_config(struct stm32_uart* uart)
 {
     LL_DMA_InitTypeDef DMA_InitStruct;
 
-    DMA_InitStruct.PeriphOrM2MSrcAddress  = (uint32_t)&uart->uart_device->TDR;
-    DMA_InitStruct.MemoryOrM2MDstAddress  = 0x00000000U; /* will be configured later */
-    DMA_InitStruct.Direction              = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
-    DMA_InitStruct.Mode                   = LL_DMA_MODE_NORMAL;
-    DMA_InitStruct.PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
-    DMA_InitStruct.MemoryOrM2MDstIncMode  = LL_DMA_MEMORY_INCREMENT;
+    DMA_InitStruct.PeriphOrM2MSrcAddress = (uint32_t)&uart->uart_device->TDR;
+    DMA_InitStruct.MemoryOrM2MDstAddress = 0x00000000U; /* will be configured later */
+    DMA_InitStruct.Direction = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
+    DMA_InitStruct.Mode = LL_DMA_MODE_NORMAL;
+    DMA_InitStruct.PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+    DMA_InitStruct.MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
     DMA_InitStruct.PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
     DMA_InitStruct.MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
-    DMA_InitStruct.NbData                 = 0x00000000U; /* will be configured later */
-    DMA_InitStruct.Channel                = uart->dma.tx_ch;
-    DMA_InitStruct.Priority               = LL_DMA_PRIORITY_HIGH;
-    DMA_InitStruct.FIFOMode               = LL_DMA_FIFOMODE_DISABLE;
-    DMA_InitStruct.FIFOThreshold          = LL_DMA_FIFOTHRESHOLD_1_4;
-    DMA_InitStruct.MemBurst               = LL_DMA_MBURST_SINGLE;
-    DMA_InitStruct.PeriphBurst            = LL_DMA_PBURST_SINGLE;
+    DMA_InitStruct.NbData = 0x00000000U; /* will be configured later */
+    DMA_InitStruct.Channel = uart->dma.tx_ch;
+    DMA_InitStruct.Priority = LL_DMA_PRIORITY_HIGH;
+    DMA_InitStruct.FIFOMode = LL_DMA_FIFOMODE_DISABLE;
+    DMA_InitStruct.FIFOThreshold = LL_DMA_FIFOTHRESHOLD_1_4;
+    DMA_InitStruct.MemBurst = LL_DMA_MBURST_SINGLE;
+    DMA_InitStruct.PeriphBurst = LL_DMA_PBURST_SINGLE;
     /* init tx dma */
     LL_DMA_Init(uart->dma.dma_device, uart->dma.tx_stream, &DMA_InitStruct);
 
@@ -732,7 +732,7 @@ static void _close_usart(struct serial_device* serial)
 
 static rt_err_t usart_configure(struct serial_device* serial, struct serial_configure* cfg)
 {
-    struct stm32_uart*   uart;
+    struct stm32_uart* uart;
     LL_USART_InitTypeDef USART_InitStructure = { 0 };
 
     RT_ASSERT(serial != RT_NULL);
@@ -763,8 +763,8 @@ static rt_err_t usart_configure(struct serial_device* serial, struct serial_conf
     }
     // TODO: Add hw flow control
     USART_InitStructure.HardwareFlowControl = LL_USART_HWCONTROL_NONE;
-    USART_InitStructure.TransferDirection   = LL_USART_DIRECTION_TX_RX;
-    USART_InitStructure.OverSampling        = LL_USART_OVERSAMPLING_16;
+    USART_InitStructure.TransferDirection = LL_USART_DIRECTION_TX_RX;
+    USART_InitStructure.OverSampling = LL_USART_OVERSAMPLING_16;
 
     /* USART need be disabled first in order to configure it */
     LL_USART_Disable(uart->uart_device);
@@ -778,7 +778,7 @@ static rt_err_t usart_configure(struct serial_device* serial, struct serial_conf
 static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg)
 {
     struct stm32_uart* uart;
-    rt_uint32_t        ctrl_arg = (rt_uint32_t)(arg);
+    rt_uint32_t ctrl_arg = (rt_uint32_t)(arg);
 
     RT_ASSERT(serial != RT_NULL);
     uart = (struct stm32_uart*)serial->parent.user_data;
@@ -806,7 +806,7 @@ static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg)
     case RT_DEVICE_CTRL_CONFIG:
         if (ctrl_arg == RT_DEVICE_FLAG_DMA_RX) {
             struct serial_rx_fifo* rx_fifo = (struct serial_rx_fifo*)serial->serial_rx;
-            struct stm32_uart*     uart    = (struct stm32_uart*)serial->parent.user_data;
+            struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
 
             if (LL_DMA_IsEnabledStream(uart->dma.dma_device, uart->dma.rx_stream)) {
                 /* dma is busy */
@@ -858,7 +858,7 @@ static int usart_putc(struct serial_device* serial, char c)
 
 static int usart_getc(struct serial_device* serial)
 {
-    int                ch = -1;
+    int ch = -1;
     struct stm32_uart* uart;
 
     RT_ASSERT(serial != RT_NULL);
@@ -894,7 +894,7 @@ static const struct usart_ops _usart_ops = {
 
 rt_err_t drv_usart_init(void)
 {
-    rt_err_t                rt_err = RT_EOK;
+    rt_err_t rt_err = RT_EOK;
     struct serial_configure config = SERIAL_DEFAULT_CONFIG;
 
     RCC_Configuration();
@@ -904,7 +904,7 @@ rt_err_t drv_usart_init(void)
     serial0.ops = &_usart_ops;
     #ifdef SERIAL0_DEFAULT_CONFIG
     struct serial_configure serial0_config = SERIAL0_DEFAULT_CONFIG;
-    serial0.config                         = serial0_config;
+    serial0.config = serial0_config;
     #else
     serial0.config = config;
     #endif
@@ -921,7 +921,7 @@ rt_err_t drv_usart_init(void)
     serial1.ops = &_usart_ops;
     #ifdef SERIAL1_DEFAULT_CONFIG
     struct serial_configure serial1_config = SERIAL1_DEFAULT_CONFIG;
-    serial1.config                         = serial1_config;
+    serial1.config = serial1_config;
     #else
     serial1.config = config;
     #endif
@@ -938,7 +938,7 @@ rt_err_t drv_usart_init(void)
     serial2.ops = &_usart_ops;
     #ifdef SERIAL2_DEFAULT_CONFIG
     struct serial_configure serial2_config = SERIAL2_DEFAULT_CONFIG;
-    serial2.config                         = serial2_config;
+    serial2.config = serial2_config;
     #else
     serial2.config = config;
     #endif
@@ -955,7 +955,7 @@ rt_err_t drv_usart_init(void)
     serial3.ops = &_usart_ops;
     #ifdef SERIAL3_DEFAULT_CONFIG
     struct serial_configure serial3_config = SERIAL3_DEFAULT_CONFIG;
-    serial3.config                         = serial3_config;
+    serial3.config = serial3_config;
     #else
     serial3.config = config;
     #endif
@@ -972,7 +972,7 @@ rt_err_t drv_usart_init(void)
     serial4.ops = &_usart_ops;
     #ifdef SERIAL4_DEFAULT_CONFIG
     struct serial_configure serial4_config = SERIAL4_DEFAULT_CONFIG;
-    serial4.config                         = serial4_config;
+    serial4.config = serial4_config;
     #else
     serial4.config = config;
     #endif
@@ -989,7 +989,7 @@ rt_err_t drv_usart_init(void)
     serial5.ops = &_usart_ops;
     #ifdef SERIAL5_DEFAULT_CONFIG
     struct serial_configure serial5_config = SERIAL5_DEFAULT_CONFIG;
-    serial5.config                         = serial5_config;
+    serial5.config = serial5_config;
     #else
     serial5.config = config;
     #endif

--- a/target/pixhawk/fmt-io/project/source/usart.c
+++ b/target/pixhawk/fmt-io/project/source/usart.c
@@ -103,7 +103,7 @@ uint8_t usart_init(void)
     GPIO_InitStructure.GPIO_Pin = GPIO_Pin_3;
     GPIO_Init(GPIOA, &GPIO_InitStructure);
 
-    USART_InitStructure.USART_BaudRate = 230400;
+    USART_InitStructure.USART_BaudRate = 921600;
     USART_InitStructure.USART_WordLength = USART_WordLength_8b;
     USART_InitStructure.USART_StopBits = USART_StopBits_1;
     USART_InitStructure.USART_Parity = USART_Parity_No;
@@ -125,7 +125,7 @@ uint8_t usart_init(void)
     GPIO_InitStructure.GPIO_Pin = GPIO_Pin_9;
     GPIO_InitStructure.GPIO_Speed = GPIO_Speed_50MHz;
     GPIO_Init(GPIOA, &GPIO_InitStructure);
-    /* Configure USART Rx as input pull up, 
+    /* Configure USART Rx as input pull up,
      * because input floating will result in unstable voltage level if sbus cable is not connected */
     GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IPU;
     GPIO_InitStructure.GPIO_Pin = GPIO_Pin_10;
@@ -146,10 +146,10 @@ uint8_t usart_init(void)
 }
 
 /**
-  * @brief  Retargets the C library printf function to the USART.
-  * @param  None
-  * @retval None
-  */
+ * @brief  Retargets the C library printf function to the USART.
+ * @param  None
+ * @retval None
+ */
 int fputc(int ch, FILE* f)
 {
     /* Place your implementation of fputc here */

--- a/target/pixhawk/fmu-v2/drivers/drv_usart.c
+++ b/target/pixhawk/fmu-v2/drivers/drv_usart.c
@@ -40,13 +40,13 @@
 #define USING_UART8
 
 /* UART GPIO define. */
-#define UART1_GPIO_TX       GPIO_Pin_9
-#define UART1_TX_PIN_SOURCE GPIO_PinSource9
-#define UART1_GPIO_RX       GPIO_Pin_10
-#define UART1_RX_PIN_SOURCE GPIO_PinSource10
-#define UART1_GPIO          GPIOA
-#define UART1_GPIO_RCC      RCC_AHB1Periph_GPIOA
-#define RCC_APBPeriph_UART1 RCC_APB2Periph_USART1
+#define UART1_GPIO_TX        GPIO_Pin_9
+#define UART1_TX_PIN_SOURCE  GPIO_PinSource9
+#define UART1_GPIO_RX        GPIO_Pin_10
+#define UART1_RX_PIN_SOURCE  GPIO_PinSource10
+#define UART1_GPIO           GPIOA
+#define UART1_GPIO_RCC       RCC_AHB1Periph_GPIOA
+#define RCC_APBPeriph_UART1  RCC_APB2Periph_USART1
 
 #define UART2_GPIO_CTS       GPIO_Pin_3
 #define UART2_CTS_PIN_SOURCE GPIO_PinSource3
@@ -72,85 +72,85 @@
 #define UART3_GPIO_RCC       RCC_AHB1Periph_GPIOD
 #define RCC_APBPeriph_UART3  RCC_APB1Periph_USART3
 
-#define UART4_GPIO_TX       GPIO_Pin_0
-#define UART4_TX_PIN_SOURCE GPIO_PinSource0
-#define UART4_GPIO_RX       GPIO_Pin_1
-#define UART4_RX_PIN_SOURCE GPIO_PinSource1
-#define UART4_GPIO          GPIOA
-#define UART4_GPIO_RCC      RCC_AHB1Periph_GPIOA
-#define RCC_APBPeriph_UART4 RCC_APB1Periph_UART4
+#define UART4_GPIO_TX        GPIO_Pin_0
+#define UART4_TX_PIN_SOURCE  GPIO_PinSource0
+#define UART4_GPIO_RX        GPIO_Pin_1
+#define UART4_RX_PIN_SOURCE  GPIO_PinSource1
+#define UART4_GPIO           GPIOA
+#define UART4_GPIO_RCC       RCC_AHB1Periph_GPIOA
+#define RCC_APBPeriph_UART4  RCC_APB1Periph_UART4
 
-#define UART6_GPIO_TX       GPIO_Pin_6
-#define UART6_TX_PIN_SOURCE GPIO_PinSource6
-#define UART6_GPIO_RX       GPIO_Pin_7
-#define UART6_RX_PIN_SOURCE GPIO_PinSource7
-#define UART6_GPIO          GPIOC
-#define UART6_GPIO_RCC      RCC_AHB1Periph_GPIOC
-#define RCC_APBPeriph_UART6 RCC_APB2Periph_USART6
+#define UART6_GPIO_TX        GPIO_Pin_6
+#define UART6_TX_PIN_SOURCE  GPIO_PinSource6
+#define UART6_GPIO_RX        GPIO_Pin_7
+#define UART6_RX_PIN_SOURCE  GPIO_PinSource7
+#define UART6_GPIO           GPIOC
+#define UART6_GPIO_RCC       RCC_AHB1Periph_GPIOC
+#define RCC_APBPeriph_UART6  RCC_APB2Periph_USART6
 
-#define UART7_GPIO_TX       GPIO_Pin_8
-#define UART7_TX_PIN_SOURCE GPIO_PinSource8
-#define UART7_GPIO_RX       GPIO_Pin_7
-#define UART7_RX_PIN_SOURCE GPIO_PinSource7
-#define UART7_GPIO          GPIOE
-#define UART7_GPIO_RCC      RCC_AHB1Periph_GPIOE
-#define RCC_APBPeriph_UART7 RCC_APB1Periph_UART7
+#define UART7_GPIO_TX        GPIO_Pin_8
+#define UART7_TX_PIN_SOURCE  GPIO_PinSource8
+#define UART7_GPIO_RX        GPIO_Pin_7
+#define UART7_RX_PIN_SOURCE  GPIO_PinSource7
+#define UART7_GPIO           GPIOE
+#define UART7_GPIO_RCC       RCC_AHB1Periph_GPIOE
+#define RCC_APBPeriph_UART7  RCC_APB1Periph_UART7
 
-#define UART8_GPIO_TX       GPIO_Pin_1
-#define UART8_TX_PIN_SOURCE GPIO_PinSource1
-#define UART8_GPIO_RX       GPIO_Pin_0
-#define UART8_RX_PIN_SOURCE GPIO_PinSource0
-#define UART8_GPIO          GPIOE
-#define UART8_GPIO_RCC      RCC_AHB1Periph_GPIOE
-#define RCC_APBPeriph_UART8 RCC_APB1Periph_UART8
+#define UART8_GPIO_TX        GPIO_Pin_1
+#define UART8_TX_PIN_SOURCE  GPIO_PinSource1
+#define UART8_GPIO_RX        GPIO_Pin_0
+#define UART8_RX_PIN_SOURCE  GPIO_PinSource0
+#define UART8_GPIO           GPIOE
+#define UART8_GPIO_RCC       RCC_AHB1Periph_GPIOE
+#define RCC_APBPeriph_UART8  RCC_APB1Periph_UART8
 
 /* config for serial_configure structure */
-#define SERIAL2_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_9600,      /* 9600 bits/s */    \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL2_DEFAULT_CONFIG                \
+    {                                         \
+        BAUD_RATE_9600,  /* 9600 bits/s */    \
+        DATA_BITS_8,     /* 8 databits */     \
+        STOP_BITS_1,     /* 1 stopbit */      \
+        PARITY_NONE,     /* No parity  */     \
+        BIT_ORDER_LSB,   /* LSB first sent */ \
+        NRZ_NORMAL,      /* Normal mode */    \
+        SERIAL_RB_BUFSZ, /* Buffer size */    \
+        0                                     \
     }
 
-#define SERIAL3_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_115200,    /* 115200 bits/s */  \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL3_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_115200, /* 115200 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        SERIAL_RB_BUFSZ,  /* Buffer size */    \
+        0                                      \
     }
 
-#define SERIAL4_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_115200,    /* 115200 bits/s */  \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL4_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_115200, /* 115200 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        SERIAL_RB_BUFSZ,  /* Buffer size */    \
+        0                                      \
     }
 
-#define SERIAL5_DEFAULT_CONFIG                  \
-    {                                           \
-        BAUD_RATE_230400,  /* 115200 bits/s */  \
-            DATA_BITS_8,   /* 8 databits */     \
-            STOP_BITS_1,   /* 1 stopbit */      \
-            PARITY_NONE,   /* No parity  */     \
-            BIT_ORDER_LSB, /* LSB first sent */ \
-            NRZ_NORMAL,    /* Normal mode */    \
-            1024,          /* Buffer size */    \
-            0                                   \
+#define SERIAL5_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_921600, /* 921600 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        1024,             /* Buffer size */    \
+        0                                      \
     }
 
 /* STM32 uart driver */
@@ -839,7 +839,7 @@ static void _dma_rx_config(struct serial_device* serial, rt_uint8_t* buf, rt_siz
         ;
 
     DMA_InitStructure.DMA_Channel = uart->dma.rx_ch;
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t) & (uart->uart_device->DR);
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&(uart->uart_device->DR);
     DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)buf;
     DMA_InitStructure.DMA_BufferSize = uart->dma.setting_recv_len;
     DMA_InitStructure.DMA_DIR = DMA_DIR_PeripheralToMemory;
@@ -896,7 +896,7 @@ static void _dma_transmit(struct serial_device* serial, rt_uint8_t* buf, rt_size
     DMA_InitStructure.DMA_Memory0BaseAddr = (uint32_t)buf;
     DMA_InitStructure.DMA_BufferSize = size;
     DMA_InitStructure.DMA_Channel = uart->dma.tx_ch;
-    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t) & (uart->uart_device->DR);
+    DMA_InitStructure.DMA_PeripheralBaseAddr = (uint32_t)&(uart->uart_device->DR);
     DMA_InitStructure.DMA_DIR = DMA_DIR_MemoryToPeripheral;
     DMA_InitStructure.DMA_PeripheralInc = DMA_PeripheralInc_Disable;
     DMA_InitStructure.DMA_MemoryInc = DMA_MemoryInc_Enable;
@@ -925,7 +925,7 @@ static void _close_usart(struct serial_device* serial)
 
     if (serial->parent.open_flag & RT_DEVICE_FLAG_INT_RX) {
         /* disable rx irq */
-        //UART_DISABLE_IRQ(uart->irq);	/* we don't disable rx irq, since dma rx need it */
+        // UART_DISABLE_IRQ(uart->irq);	/* we don't disable rx irq, since dma rx need it */
         /* disable interrupt */
         USART_ITConfig(uart->uart_device, USART_IT_RXNE, DISABLE);
     }

--- a/target/pixhawk/fmu-v5/drivers/drv_usart.c
+++ b/target/pixhawk/fmu-v5/drivers/drv_usart.c
@@ -39,46 +39,46 @@
 #define USING_UART8
 
 /* config for serial_configure structure */
-#define SERIAL3_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_9600,      /* 9600 bits/s */    \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL3_DEFAULT_CONFIG                \
+    {                                         \
+        BAUD_RATE_9600,  /* 9600 bits/s */    \
+        DATA_BITS_8,     /* 8 databits */     \
+        STOP_BITS_1,     /* 1 stopbit */      \
+        PARITY_NONE,     /* No parity  */     \
+        BIT_ORDER_LSB,   /* LSB first sent */ \
+        NRZ_NORMAL,      /* Normal mode */    \
+        SERIAL_RB_BUFSZ, /* Buffer size */    \
+        0                                     \
     }
 
-#define SERIAL4_DEFAULT_CONFIG                    \
-    {                                             \
-        BAUD_RATE_115200,    /* 115200 bits/s */  \
-            DATA_BITS_8,     /* 8 databits */     \
-            STOP_BITS_1,     /* 1 stopbit */      \
-            PARITY_NONE,     /* No parity  */     \
-            BIT_ORDER_LSB,   /* LSB first sent */ \
-            NRZ_NORMAL,      /* Normal mode */    \
-            SERIAL_RB_BUFSZ, /* Buffer size */    \
-            0                                     \
+#define SERIAL4_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_115200, /* 115200 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        SERIAL_RB_BUFSZ,  /* Buffer size */    \
+        0                                      \
     }
 
-#define SERIAL5_DEFAULT_CONFIG                  \
-    {                                           \
-        BAUD_RATE_230400,  /* 230400 bits/s */  \
-            DATA_BITS_8,   /* 8 databits */     \
-            STOP_BITS_1,   /* 1 stopbit */      \
-            PARITY_NONE,   /* No parity  */     \
-            BIT_ORDER_LSB, /* LSB first sent */ \
-            NRZ_NORMAL,    /* Normal mode */    \
-            1024,          /* Buffer size */    \
-            0                                   \
+#define SERIAL5_DEFAULT_CONFIG                 \
+    {                                          \
+        BAUD_RATE_921600, /* 921600 bits/s */  \
+        DATA_BITS_8,      /* 8 databits */     \
+        STOP_BITS_1,      /* 1 stopbit */      \
+        PARITY_NONE,      /* No parity  */     \
+        BIT_ORDER_LSB,    /* LSB first sent */ \
+        NRZ_NORMAL,       /* Normal mode */    \
+        1024,             /* Buffer size */    \
+        0                                      \
     }
 
 /* STM32 uart driver */
 struct stm32_uart {
     USART_TypeDef* uart_device;
-    IRQn_Type      irq;
+    IRQn_Type irq;
     struct stm32_uart_dma {
         /* dma instance */
         DMA_TypeDef* dma_device;
@@ -102,10 +102,10 @@ struct stm32_uart {
 };
 
 static rt_size_t usart_dma_transmit(struct serial_device* serial, rt_uint8_t* buf, rt_size_t size, int direction);
-static int       usart_getc(struct serial_device* serial);
-static int       usart_putc(struct serial_device* serial, char c);
-static rt_err_t  usart_control(struct serial_device* serial, int cmd, void* arg);
-static rt_err_t  usart_configure(struct serial_device* serial, struct serial_configure* cfg);
+static int usart_getc(struct serial_device* serial);
+static int usart_putc(struct serial_device* serial, char c);
+static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg);
+static rt_err_t usart_configure(struct serial_device* serial, struct serial_configure* cfg);
 
 static void _dma_clear_flags(DMA_TypeDef* dma, uint32_t stream)
 {
@@ -127,9 +127,9 @@ static void _dma_clear_flags(DMA_TypeDef* dma, uint32_t stream)
 static void dma_uart_rx_idle_isr(struct serial_device* serial)
 {
     struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
-    rt_size_t          recv_total_index, recv_len;
-    rt_base_t          level;
-    uint32_t           remain_bytes;
+    rt_size_t recv_total_index, recv_len;
+    rt_base_t level;
+    uint32_t remain_bytes;
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -158,8 +158,8 @@ static void dma_uart_rx_idle_isr(struct serial_device* serial)
 static void dma_rx_done_isr(struct serial_device* serial)
 {
     struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
-    rt_size_t          recv_len;
-    rt_base_t          level;
+    rt_size_t recv_len;
+    rt_base_t level;
 
     /* disable interrupt */
     level = rt_hw_interrupt_disable();
@@ -234,17 +234,17 @@ static struct serial_device serial3; // GPS
 /* UART2 device driver structure */
 struct stm32_uart uart1 = {
     .uart_device = USART1,
-    .irq         = USART1_IRQn,
-    .dma         = {
-                .dma_device       = DMA2,
-                .rx_stream        = LL_DMA_STREAM_2,
-                .rx_ch            = LL_DMA_CHANNEL_4,
-                .rx_irq           = DMA2_Stream2_IRQn,
-                .tx_stream        = LL_DMA_STREAM_7,
-                .tx_ch            = LL_DMA_CHANNEL_4,
-                .tx_irq           = DMA2_Stream7_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = USART1_IRQn,
+    .dma = {
+        .dma_device = DMA2,
+        .rx_stream = LL_DMA_STREAM_2,
+        .rx_ch = LL_DMA_CHANNEL_4,
+        .rx_irq = DMA2_Stream2_IRQn,
+        .tx_stream = LL_DMA_STREAM_7,
+        .tx_ch = LL_DMA_CHANNEL_4,
+        .tx_irq = DMA2_Stream7_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -294,8 +294,8 @@ static struct serial_device serial1; // TELEM1
 /* UART2 device driver structure */
 struct stm32_uart uart2 = {
     .uart_device = USART2,
-    .irq         = USART2_IRQn,
-    .dma         = { 0 }
+    .irq = USART2_IRQn,
+    .dma = { 0 }
 };
 
 void USART2_IRQHandler(void)
@@ -315,17 +315,17 @@ static struct serial_device serial2; // TELEM2
 /* UART3 device driver structure */
 struct stm32_uart uart3 = {
     .uart_device = USART3,
-    .irq         = USART3_IRQn,
-    .dma         = {
-                .dma_device       = DMA1,
-                .rx_stream        = LL_DMA_STREAM_1,
-                .rx_ch            = LL_DMA_CHANNEL_4,
-                .rx_irq           = DMA1_Stream1_IRQn,
-                .tx_stream        = LL_DMA_STREAM_3,
-                .tx_ch            = LL_DMA_CHANNEL_4,
-                .tx_irq           = DMA1_Stream3_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = USART3_IRQn,
+    .dma = {
+        .dma_device = DMA1,
+        .rx_stream = LL_DMA_STREAM_1,
+        .rx_ch = LL_DMA_CHANNEL_4,
+        .rx_irq = DMA1_Stream1_IRQn,
+        .tx_stream = LL_DMA_STREAM_3,
+        .tx_ch = LL_DMA_CHANNEL_4,
+        .tx_irq = DMA1_Stream3_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -376,7 +376,7 @@ static struct serial_device serial4; // UART4
 /* UART2 device driver structure */
 static struct stm32_uart uart4 = {
     .uart_device = UART4,
-    .irq         = UART4_IRQn,
+    .irq = UART4_IRQn,
 };
 
 void UART4_IRQHandler(void)
@@ -396,8 +396,8 @@ static struct serial_device serial0; // FMU Debug
 /* UART7 device driver structure */
 struct stm32_uart uart7 = {
     .uart_device = UART7,
-    .irq         = UART7_IRQn,
-    .dma         = { 0 }
+    .irq = UART7_IRQn,
+    .dma = { 0 }
 };
 
 void UART7_IRQHandler(void)
@@ -417,17 +417,17 @@ static struct serial_device serial5; // FMTIO
 /* UART7 device driver structure */
 struct stm32_uart uart8 = {
     .uart_device = UART8,
-    .irq         = UART8_IRQn,
-    .dma         = {
-                .dma_device       = DMA1,
-                .rx_stream        = LL_DMA_STREAM_6,
-                .rx_ch            = LL_DMA_CHANNEL_5,
-                .rx_irq           = DMA1_Stream6_IRQn,
-                .tx_stream        = LL_DMA_STREAM_0,
-                .tx_ch            = LL_DMA_CHANNEL_5,
-                .tx_irq           = DMA1_Stream0_IRQn,
-                .setting_recv_len = 0,
-                .last_recv_index  = 0,
+    .irq = UART8_IRQn,
+    .dma = {
+        .dma_device = DMA1,
+        .rx_stream = LL_DMA_STREAM_6,
+        .rx_ch = LL_DMA_CHANNEL_5,
+        .rx_irq = DMA1_Stream6_IRQn,
+        .tx_stream = LL_DMA_STREAM_0,
+        .tx_ch = LL_DMA_CHANNEL_5,
+        .tx_irq = DMA1_Stream0_IRQn,
+        .setting_recv_len = 0,
+        .last_recv_index = 0,
     },
 };
 
@@ -514,67 +514,67 @@ static void GPIO_Configuration(void)
 {
     LL_GPIO_InitTypeDef GPIO_InitStruct = { 0 };
 
-    GPIO_InitStruct.Mode       = LL_GPIO_MODE_ALTERNATE;
-    GPIO_InitStruct.Speed      = LL_GPIO_SPEED_FREQ_VERY_HIGH;
+    GPIO_InitStruct.Mode = LL_GPIO_MODE_ALTERNATE;
+    GPIO_InitStruct.Speed = LL_GPIO_SPEED_FREQ_VERY_HIGH;
     GPIO_InitStruct.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
-    GPIO_InitStruct.Pull       = LL_GPIO_PULL_UP;
+    GPIO_InitStruct.Pull = LL_GPIO_PULL_UP;
 
 #ifdef USING_UART1
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_7;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_7;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOB, &GPIO_InitStruct);
 #endif /* USING_UART1 */
 
 #ifdef USING_UART2
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_5;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_5;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART2 */
 
 #ifdef USING_UART3
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_9;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_9;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_8;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_8;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_7;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART3 */
 
 #ifdef USING_UART4
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_0;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_0;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_1;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_1;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOD, &GPIO_InitStruct);
 #endif /* USING_UART4 */
 
 #ifdef USING_UART7
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_6;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_6;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOF, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_8;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_8;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 #endif /* USING_UART7 */
 
 #ifdef USING_UART8
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_1;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_1;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 
-    GPIO_InitStruct.Pin       = LL_GPIO_PIN_0;
+    GPIO_InitStruct.Pin = LL_GPIO_PIN_0;
     GPIO_InitStruct.Alternate = LL_GPIO_AF_8;
     LL_GPIO_Init(GPIOE, &GPIO_InitStruct);
 #endif /* USING_UART8 */
@@ -650,21 +650,21 @@ static void _dma_rx_config(struct stm32_uart* uart, rt_uint8_t* buf, rt_size_t s
     /* set expected receive length */
     uart->dma.setting_recv_len = size;
 
-    DMA_InitStruct.PeriphOrM2MSrcAddress  = (uint32_t)&uart->uart_device->RDR;
-    DMA_InitStruct.MemoryOrM2MDstAddress  = (uint32_t)buf;
-    DMA_InitStruct.Direction              = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
-    DMA_InitStruct.Mode                   = LL_DMA_MODE_CIRCULAR;
-    DMA_InitStruct.PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
-    DMA_InitStruct.MemoryOrM2MDstIncMode  = LL_DMA_MEMORY_INCREMENT;
+    DMA_InitStruct.PeriphOrM2MSrcAddress = (uint32_t)&uart->uart_device->RDR;
+    DMA_InitStruct.MemoryOrM2MDstAddress = (uint32_t)buf;
+    DMA_InitStruct.Direction = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
+    DMA_InitStruct.Mode = LL_DMA_MODE_CIRCULAR;
+    DMA_InitStruct.PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+    DMA_InitStruct.MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
     DMA_InitStruct.PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
     DMA_InitStruct.MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
-    DMA_InitStruct.NbData                 = size;
-    DMA_InitStruct.Channel                = uart->dma.rx_ch;
-    DMA_InitStruct.Priority               = LL_DMA_PRIORITY_HIGH;
-    DMA_InitStruct.FIFOMode               = LL_DMA_FIFOMODE_DISABLE;
-    DMA_InitStruct.FIFOThreshold          = LL_DMA_FIFOTHRESHOLD_1_4;
-    DMA_InitStruct.MemBurst               = LL_DMA_MBURST_SINGLE;
-    DMA_InitStruct.PeriphBurst            = LL_DMA_PBURST_SINGLE;
+    DMA_InitStruct.NbData = size;
+    DMA_InitStruct.Channel = uart->dma.rx_ch;
+    DMA_InitStruct.Priority = LL_DMA_PRIORITY_HIGH;
+    DMA_InitStruct.FIFOMode = LL_DMA_FIFOMODE_DISABLE;
+    DMA_InitStruct.FIFOThreshold = LL_DMA_FIFOTHRESHOLD_1_4;
+    DMA_InitStruct.MemBurst = LL_DMA_MBURST_SINGLE;
+    DMA_InitStruct.PeriphBurst = LL_DMA_PBURST_SINGLE;
     /* init rx dma */
     LL_DMA_Init(uart->dma.dma_device, uart->dma.rx_stream, &DMA_InitStruct);
 
@@ -680,21 +680,21 @@ static void _dma_tx_config(struct stm32_uart* uart)
 {
     LL_DMA_InitTypeDef DMA_InitStruct;
 
-    DMA_InitStruct.PeriphOrM2MSrcAddress  = (uint32_t)&uart->uart_device->TDR;
-    DMA_InitStruct.MemoryOrM2MDstAddress  = 0x00000000U; /* will be configured later */
-    DMA_InitStruct.Direction              = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
-    DMA_InitStruct.Mode                   = LL_DMA_MODE_NORMAL;
-    DMA_InitStruct.PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
-    DMA_InitStruct.MemoryOrM2MDstIncMode  = LL_DMA_MEMORY_INCREMENT;
+    DMA_InitStruct.PeriphOrM2MSrcAddress = (uint32_t)&uart->uart_device->TDR;
+    DMA_InitStruct.MemoryOrM2MDstAddress = 0x00000000U; /* will be configured later */
+    DMA_InitStruct.Direction = LL_DMA_DIRECTION_MEMORY_TO_PERIPH;
+    DMA_InitStruct.Mode = LL_DMA_MODE_NORMAL;
+    DMA_InitStruct.PeriphOrM2MSrcIncMode = LL_DMA_PERIPH_NOINCREMENT;
+    DMA_InitStruct.MemoryOrM2MDstIncMode = LL_DMA_MEMORY_INCREMENT;
     DMA_InitStruct.PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
     DMA_InitStruct.MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
-    DMA_InitStruct.NbData                 = 0x00000000U; /* will be configured later */
-    DMA_InitStruct.Channel                = uart->dma.tx_ch;
-    DMA_InitStruct.Priority               = LL_DMA_PRIORITY_HIGH;
-    DMA_InitStruct.FIFOMode               = LL_DMA_FIFOMODE_DISABLE;
-    DMA_InitStruct.FIFOThreshold          = LL_DMA_FIFOTHRESHOLD_1_4;
-    DMA_InitStruct.MemBurst               = LL_DMA_MBURST_SINGLE;
-    DMA_InitStruct.PeriphBurst            = LL_DMA_PBURST_SINGLE;
+    DMA_InitStruct.NbData = 0x00000000U; /* will be configured later */
+    DMA_InitStruct.Channel = uart->dma.tx_ch;
+    DMA_InitStruct.Priority = LL_DMA_PRIORITY_HIGH;
+    DMA_InitStruct.FIFOMode = LL_DMA_FIFOMODE_DISABLE;
+    DMA_InitStruct.FIFOThreshold = LL_DMA_FIFOTHRESHOLD_1_4;
+    DMA_InitStruct.MemBurst = LL_DMA_MBURST_SINGLE;
+    DMA_InitStruct.PeriphBurst = LL_DMA_PBURST_SINGLE;
     /* init tx dma */
     LL_DMA_Init(uart->dma.dma_device, uart->dma.tx_stream, &DMA_InitStruct);
 
@@ -732,7 +732,7 @@ static void _close_usart(struct serial_device* serial)
 
 static rt_err_t usart_configure(struct serial_device* serial, struct serial_configure* cfg)
 {
-    struct stm32_uart*   uart;
+    struct stm32_uart* uart;
     LL_USART_InitTypeDef USART_InitStructure = { 0 };
 
     RT_ASSERT(serial != RT_NULL);
@@ -763,8 +763,8 @@ static rt_err_t usart_configure(struct serial_device* serial, struct serial_conf
     }
     // TODO: Add hw flow control
     USART_InitStructure.HardwareFlowControl = LL_USART_HWCONTROL_NONE;
-    USART_InitStructure.TransferDirection   = LL_USART_DIRECTION_TX_RX;
-    USART_InitStructure.OverSampling        = LL_USART_OVERSAMPLING_16;
+    USART_InitStructure.TransferDirection = LL_USART_DIRECTION_TX_RX;
+    USART_InitStructure.OverSampling = LL_USART_OVERSAMPLING_16;
 
     /* USART need be disabled first in order to configure it */
     LL_USART_Disable(uart->uart_device);
@@ -779,7 +779,7 @@ static rt_err_t usart_configure(struct serial_device* serial, struct serial_conf
 static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg)
 {
     struct stm32_uart* uart;
-    rt_uint32_t        ctrl_arg = (rt_uint32_t)(arg);
+    rt_uint32_t ctrl_arg = (rt_uint32_t)(arg);
 
     RT_ASSERT(serial != RT_NULL);
     uart = (struct stm32_uart*)serial->parent.user_data;
@@ -807,7 +807,7 @@ static rt_err_t usart_control(struct serial_device* serial, int cmd, void* arg)
     case RT_DEVICE_CTRL_CONFIG:
         if (ctrl_arg == RT_DEVICE_FLAG_DMA_RX) {
             struct serial_rx_fifo* rx_fifo = (struct serial_rx_fifo*)serial->serial_rx;
-            struct stm32_uart*     uart    = (struct stm32_uart*)serial->parent.user_data;
+            struct stm32_uart* uart = (struct stm32_uart*)serial->parent.user_data;
 
             if (LL_DMA_IsEnabledStream(uart->dma.dma_device, uart->dma.rx_stream)) {
                 /* dma is busy */
@@ -859,7 +859,7 @@ static int usart_putc(struct serial_device* serial, char c)
 
 static int usart_getc(struct serial_device* serial)
 {
-    int                ch = -1;
+    int ch = -1;
     struct stm32_uart* uart;
 
     RT_ASSERT(serial != RT_NULL);
@@ -895,7 +895,7 @@ static const struct usart_ops _usart_ops = {
 
 rt_err_t drv_usart_init(void)
 {
-    rt_err_t                rt_err = RT_EOK;
+    rt_err_t rt_err = RT_EOK;
     struct serial_configure config = SERIAL_DEFAULT_CONFIG;
 
     RCC_Configuration();
@@ -905,7 +905,7 @@ rt_err_t drv_usart_init(void)
     serial0.ops = &_usart_ops;
     #ifdef SERIAL0_DEFAULT_CONFIG
     struct serial_configure serial0_config = SERIAL0_DEFAULT_CONFIG;
-    serial0.config                         = serial0_config;
+    serial0.config = serial0_config;
     #else
     serial0.config = config;
     #endif
@@ -922,7 +922,7 @@ rt_err_t drv_usart_init(void)
     serial1.ops = &_usart_ops;
     #ifdef SERIAL1_DEFAULT_CONFIG
     struct serial_configure serial1_config = SERIAL1_DEFAULT_CONFIG;
-    serial1.config                         = serial1_config;
+    serial1.config = serial1_config;
     #else
     serial1.config = config;
     #endif
@@ -939,7 +939,7 @@ rt_err_t drv_usart_init(void)
     serial2.ops = &_usart_ops;
     #ifdef SERIAL2_DEFAULT_CONFIG
     struct serial_configure serial2_config = SERIAL2_DEFAULT_CONFIG;
-    serial2.config                         = serial2_config;
+    serial2.config = serial2_config;
     #else
     serial2.config = config;
     #endif
@@ -956,7 +956,7 @@ rt_err_t drv_usart_init(void)
     serial3.ops = &_usart_ops;
     #ifdef SERIAL3_DEFAULT_CONFIG
     struct serial_configure serial3_config = SERIAL3_DEFAULT_CONFIG;
-    serial3.config                         = serial3_config;
+    serial3.config = serial3_config;
     #else
     serial3.config = config;
     #endif
@@ -973,7 +973,7 @@ rt_err_t drv_usart_init(void)
     serial4.ops = &_usart_ops;
     #ifdef SERIAL4_DEFAULT_CONFIG
     struct serial_configure serial4_config = SERIAL4_DEFAULT_CONFIG;
-    serial4.config                         = serial4_config;
+    serial4.config = serial4_config;
     #else
     serial4.config = config;
     #endif
@@ -990,7 +990,7 @@ rt_err_t drv_usart_init(void)
     serial5.ops = &_usart_ops;
     #ifdef SERIAL5_DEFAULT_CONFIG
     struct serial_configure serial5_config = SERIAL5_DEFAULT_CONFIG;
-    serial5.config                         = serial5_config;
+    serial5.config = serial5_config;
     #else
     serial5.config = config;
     #endif


### PR DESCRIPTION
修改的载板：
cuav/7_nano、cuav/v5_nano、minimum/cuav/v5_plus、pixhawk/fmu-v2、pixhawk/fmu-v5

在v6c上测试正常
<img width="610" height="100" alt="image" src="https://github.com/user-attachments/assets/dd34ebe6-11aa-4fdf-815e-9fefe437e668" />
