### PR TITLE
[ftp]修复出现瞬时发送失败，导致地面站等待旧 ACK 超时问题

### DIFF
--- a/src/hal/usb/usbd_cdc.c
+++ b/src/hal/usb/usbd_cdc.c
@@ -72,6 +72,7 @@ static rt_size_t hal_usbd_cdc_write(rt_device_t dev, rt_off_t pos, const void* b
 {
     usbd_cdc_dev_t usbd = (usbd_cdc_dev_t)dev;
     rt_size_t wb = 0;
+    rt_err_t err;
 
     RT_ASSERT(dev != RT_NULL);
 
@@ -83,12 +84,23 @@ static rt_size_t hal_usbd_cdc_write(rt_device_t dev, rt_off_t pos, const void* b
         return 0;
     }
 
+    /* clear stale completion before a new write attempt */
+    rt_completion_init(&usbd->tx_cplt);
+
     if (usbd->ops->dev_write) {
         wb = usbd->ops->dev_write(usbd, pos, buffer, size);
     }
 
+    if (wb == 0) {
+        rt_mutex_release(usbd->tx_lock);
+        return 0;
+    }
+
     /* wait until send is finished */
-    rt_completion_wait(&usbd->tx_cplt, TICKS_FROM_MS(USBD_WAIT_TIMEOUT));
+    err = rt_completion_wait(&usbd->tx_cplt, TICKS_FROM_MS(USBD_WAIT_TIMEOUT));
+    if (err != RT_EOK) {
+        wb = 0;
+    }
 
     rt_mutex_release(usbd->tx_lock);
     return wb;

--- a/src/module/ftp/ftp_manager.c
+++ b/src/module/ftp/ftp_manager.c
@@ -427,6 +427,9 @@ fmt_err_t ftp_stream_send(StreamSession* stream_session)
     uint8_t err_no;
     mavlink_system_t system;
     int br;
+    uint16_t seq_number;
+    uint32_t stream_offset;
+    fmt_err_t send_ret;
 
     FTP_DBG("send stream, seq:%d offset:%d fd:%d", stream_session->stream_seq_number, stream_session->stream_offset, stream_session->fd);
 
@@ -435,21 +438,18 @@ fmt_err_t ftp_stream_send(StreamSession* stream_session)
         return FMT_ERROR;
     }
 
-    ftp_msg_t->seq_number = stream_session->stream_seq_number;
-    ftp_msg_t->offset = stream_session->stream_offset;
+    seq_number = stream_session->stream_seq_number;
+    stream_offset = stream_session->stream_offset;
+
+    ftp_msg_t->seq_number = seq_number;
+    ftp_msg_t->offset = stream_offset;
     ftp_msg_t->session = 0;
     ftp_msg_t->burst_complete = 0;
     ftp_msg_t->opcode = kRspAck;
     ftp_msg_t->req_opcode = kCmdBurstReadFile;
 
-    stream_session->stream_seq_number++;
-
-    if (ftp_msg_t->offset >= stream_session->file_size) {
+    if (stream_offset >= stream_session->file_size) {
         /* stream session complete */
-        mavproxy_cmd_reset(MAVCMD_STREAM_SESSION);
-
-        stream_session->complete = 1;
-
         err_code = kErrEOF;
 
         FTP_DBG("stream session complete");
@@ -463,18 +463,18 @@ fmt_err_t ftp_stream_send(StreamSession* stream_session)
     // 	goto Out;
     // }
 
-    off_t off = lseek(stream_session->fd, ftp_msg_t->offset, SEEK_SET);
+    off_t off = lseek(stream_session->fd, stream_offset, SEEK_SET);
 
-    if (off != ftp_msg_t->offset) {
+    if (off != stream_offset) {
         err_no = rt_get_errno();
         err_code = kErrFailErrno;
 
-        FTP_DBG("seek fail:%d, offset:%d cur_offset:%d", err_no, ftp_msg_t->offset, off);
+        FTP_DBG("seek fail:%d, offset:%d cur_offset:%d", err_no, stream_offset, off);
         goto Out;
     }
 
     // fres = f_read(stream_session->fd, ftp_msg_t->data, MAX_FTP_DATA_LEN, &br);
-    size_t len_to_read = stream_session->file_size - ftp_msg_t->offset;
+    size_t len_to_read = stream_session->file_size - stream_offset;
     len_to_read = len_to_read > MAX_FTP_DATA_LEN ? MAX_FTP_DATA_LEN : len_to_read;
     br = read(stream_session->fd, ftp_msg_t->data, len_to_read);
 
@@ -498,13 +498,11 @@ Out:
 
     if (err_code == kErrNone) {
         ftp_msg_t->opcode = kRspAck;
-        stream_session->stream_offset += ftp_msg_t->size;
-
-        if (stream_session->stream_offset >= stream_session->file_size) {
+        if ((stream_offset + ftp_msg_t->size) >= stream_session->file_size) {
             ftp_msg_t->burst_complete = 1;
         }
 
-        FTP_DBG("RspAck, size:%d offset:%d complete:%d", ftp_msg_t->size, stream_session->stream_offset, ftp_msg_t->burst_complete);
+        FTP_DBG("RspAck, size:%d offset:%d complete:%d", ftp_msg_t->size, stream_offset + ftp_msg_t->size, ftp_msg_t->burst_complete);
     } else {
         ftp_msg_t->opcode = kRspNak;
         ftp_msg_t->size = 1;
@@ -527,7 +525,19 @@ Out:
     system = mavproxy_get_system();
 
     mavlink_msg_file_transfer_protocol_encode(system.sysid, system.compid, &msg, &ftp_protocol_t);
-    mavproxy_send_immediate_msg(MAVPROXY_GCS_CHAN, &msg, true);
+    send_ret = mavproxy_send_immediate_msg(MAVPROXY_GCS_CHAN, &msg, true);
+    if (send_ret != FMT_EOK) {
+        return FMT_ERROR;
+    }
+
+    /* advance stream state only after packet is sent successfully */
+    stream_session->stream_seq_number = seq_number + 1;
+    if (err_code == kErrNone) {
+        stream_session->stream_offset = stream_offset + ftp_msg_t->size;
+    } else if (err_code == kErrEOF) {
+        mavproxy_cmd_reset(MAVCMD_STREAM_SESSION);
+        stream_session->complete = 1;
+    }
 
     return FMT_EOK;
 }


### PR DESCRIPTION
`ftp_stream_send` API中只要出现一次底层瞬时发送失败，就会出现“状态已前移但包没发出”，最终导致地面站等待旧 ACK 超时。

解决方法：将发送状态从发送前，改为发送成功后，保证协议状态与真实链路发送结果一致，避免 ACK 丢失后状态导致连续超时。