### PR TITLE
Move low frequency sensors to lower priority thread

### DIFF
--- a/src/fmt_def.h
+++ b/src/fmt_def.h
@@ -24,17 +24,18 @@ extern "C" {
 #endif
 
 /* Firmament version information */
-#define FMT_VERSION                "v1.1.3"
+#define FMT_VERSION                      "v1.1.3"
 
 /* Thread Prority */
-#define VEHICLE_THREAD_PRIORITY    3
-#define FMTIO_THREAD_PRIORITY      7
-#define DRONECAN_THREAD_PRIORITY   4
-#define MAVLINK_RX_THREAD_PRIORITY 10
-#define MAVGCS_THREAD_PRIORITY     11
-#define MAVOBC_THREAD_PRIORITY     12
-#define LOGGER_THREAD_PRIORITY     13
-#define STATUS_THREAD_PRIORITY     14
+#define VEHICLE_THREAD_PRIORITY          3
+#define LOW_FREQ_SENSORS_THREAD_PRIORITY 4
+#define FMTIO_THREAD_PRIORITY            7
+#define DRONECAN_THREAD_PRIORITY         4
+#define MAVLINK_RX_THREAD_PRIORITY       10
+#define MAVGCS_THREAD_PRIORITY           11
+#define MAVOBC_THREAD_PRIORITY           12
+#define LOGGER_THREAD_PRIORITY           13
+#define STATUS_THREAD_PRIORITY           14
 
 #if !defined(bool) && !defined(__cplusplus)
 typedef int bool;

--- a/src/module/sensor/sensor_hub.c
+++ b/src/module/sensor/sensor_hub.c
@@ -680,11 +680,10 @@ fmt_err_t register_sensor_airspeed(const char* dev_name)
  * @brief Collect sensor data
  * @note Should be invoked periodically. e.g, at 1KHz
  */
-void sensor_collect(void)
+void sensor_collect_high_freq(void)
 {
     float temp[3];
     enum Rotation board_rot = PARAM_GET_UINT8(CALIB, SENS_BOARD_ROT);
-    enum Rotation mag0_rot = PARAM_GET_UINT8(CALIB, CAL_MAG0_ROT);
 
     /*
      * Collect imu data
@@ -755,6 +754,13 @@ void sensor_collect(void)
             }
         }
     }
+}
+
+void sensor_collect_low_freq(void)
+{
+    float temp[3];
+    enum Rotation board_rot = PARAM_GET_UINT8(CALIB, SENS_BOARD_ROT);
+    enum Rotation mag0_rot = PARAM_GET_UINT8(CALIB, CAL_MAG0_ROT);
 
     /*
      * Collect magnetometer data
@@ -845,4 +851,10 @@ void sensor_collect(void)
             }
         }
     }
+}
+
+void sensor_collect(void)
+{
+    sensor_collect_high_freq();
+    sensor_collect_low_freq();
 }

--- a/src/module/sensor/sensor_hub.h
+++ b/src/module/sensor/sensor_hub.h
@@ -139,6 +139,8 @@ typedef struct {
 } airspeed_data_t;
 
 void sensor_collect(void);
+void sensor_collect_high_freq(void);
+void sensor_collect_low_freq(void);
 fmt_err_t sensor_update_calibration(void);
 fmt_err_t advertise_sensor_imu(uint8_t id);
 fmt_err_t advertise_sensor_mag(uint8_t id);

--- a/src/task/low_freq_sensors/task_low_freq_sensors.c
+++ b/src/task/low_freq_sensors/task_low_freq_sensors.c
@@ -1,0 +1,81 @@
+/******************************************************************************
+ * Copyright 2020 The Firmament Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *****************************************************************************/
+
+#include <firmament.h>
+
+#include "module/sensor/sensor_hub.h"
+#include "module/system/systime.h"
+#include "module/task_manager/task_manager.h"
+
+#define LOW_FREQ_SENSORS_PERIOD_MS    10
+#define EVENT_LOW_FREQ_SENSORS_UPDATE (1 << 0)
+
+static struct rt_timer timer_low_freq_sensors;
+static struct rt_event event_low_freq_sensors;
+
+static void timer_low_freq_sensors_update(void* parameter)
+{
+    rt_event_send(&event_low_freq_sensors, EVENT_LOW_FREQ_SENSORS_UPDATE);
+}
+
+fmt_err_t task_low_freq_sensors_init(void)
+{
+    if (rt_event_init(&event_low_freq_sensors, "lfsens", RT_IPC_FLAG_FIFO) != RT_EOK) {
+        return FMT_ERROR;
+    }
+
+    rt_timer_init(&timer_low_freq_sensors,
+                  "lfsens",
+                  timer_low_freq_sensors_update,
+                  RT_NULL,
+                  TICKS_FROM_MS(LOW_FREQ_SENSORS_PERIOD_MS),
+                  RT_TIMER_FLAG_PERIODIC | RT_TIMER_FLAG_HARD_TIMER);
+    if (rt_timer_start(&timer_low_freq_sensors) != RT_EOK) {
+        return FMT_ERROR;
+    }
+
+    return FMT_EOK;
+}
+
+void task_low_freq_sensors_entry(void* parameter)
+{
+    rt_err_t res;
+    rt_uint32_t recv_set = 0;
+    uint32_t wait_set = EVENT_LOW_FREQ_SENSORS_UPDATE;
+
+    while (1) {
+        res = rt_event_recv(&event_low_freq_sensors, wait_set, RT_EVENT_FLAG_OR | RT_EVENT_FLAG_CLEAR, RT_WAITING_FOREVER, &recv_set);
+
+        if (res == RT_EOK) {
+            if (recv_set & EVENT_LOW_FREQ_SENSORS_UPDATE) {
+#if !defined(FMT_USING_HIL) && !defined(FMT_USING_SIH)
+                sensor_collect_low_freq();
+#endif
+            }
+        }
+    }
+}
+
+TASK_EXPORT __fmt_task_desc = {
+    .name = "low_freq_sensors",
+    .init = task_low_freq_sensors_init,
+    .entry = task_low_freq_sensors_entry,
+    .priority = LOW_FREQ_SENSORS_THREAD_PRIORITY,
+    .auto_start = true,
+    .stack_size = 3072,
+    .param = NULL,
+    .dependency = NULL
+};

--- a/src/task/vehicle/normal/task_vehicle.c
+++ b/src/task/vehicle/normal/task_vehicle.c
@@ -61,7 +61,7 @@ void task_vehicle_entry(void* parameter)
                 timestamp = time_now - systime_get_origin();
 
 #if !defined(FMT_USING_HIL) && !defined(FMT_USING_SIH)
-                sensor_collect();
+                sensor_collect_high_freq();
 #endif
                 pilot_cmd_collect();
                 gcs_cmd_collect();

--- a/target/amov/icf5/config/task.py
+++ b/target/amov/icf5/config/task.py
@@ -5,6 +5,7 @@ TASKS = [
     'logger/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []

--- a/target/cuav/7_nano/config/task.py
+++ b/target/cuav/7_nano/config/task.py
@@ -5,6 +5,7 @@ TASKS = [
     'logger/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []

--- a/target/cuav/v5_nano/config/task.py
+++ b/target/cuav/v5_nano/config/task.py
@@ -6,6 +6,7 @@ TASKS = [
     # 'fmtio/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []

--- a/target/cuav/v5_plus/config/task.py
+++ b/target/cuav/v5_plus/config/task.py
@@ -6,6 +6,7 @@ TASKS = [
     'fmtio/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []

--- a/target/pixhawk/fmu-v2/config/task.py
+++ b/target/pixhawk/fmu-v2/config/task.py
@@ -2,6 +2,7 @@
 
 TASKS = [
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
     'comm/*.c',
     'logger/*.c',
     'fmtio/*.c',

--- a/target/pixhawk/fmu-v5/config/task.py
+++ b/target/pixhawk/fmu-v5/config/task.py
@@ -6,6 +6,7 @@ TASKS = [
     'fmtio/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []

--- a/target/pixhawk/fmu-v6c/config/task.py
+++ b/target/pixhawk/fmu-v6c/config/task.py
@@ -6,6 +6,7 @@ TASKS = [
     'fmtio/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []

--- a/target/qemu/qemu-vexpress-a9/config/task.py
+++ b/target/qemu/qemu-vexpress-a9/config/task.py
@@ -5,6 +5,7 @@ TASKS = [
     'logger/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []

--- a/target/sieon/s1/config/task.py
+++ b/target/sieon/s1/config/task.py
@@ -5,6 +5,7 @@ TASKS = [
     'logger/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []

--- a/target/yundrone/x1/config/task.py
+++ b/target/yundrone/x1/config/task.py
@@ -5,6 +5,7 @@ TASKS = [
     'logger/*.c',
     'status/*.c',
     'vehicle/normal/*.c',
+    'low_freq_sensors/*.c',
 ]
 
 TASKS_CPPPATH = []


### PR DESCRIPTION
在debug状态下，v6c的vehicle线程已经难以满足1000hz的稳定运行，主要原因在于低频传感器（100hz的mag、baro，10hz的gps等）的读取会在某一次循环中同时触发，于是这一次循环的耗时超过了1ms，整体频率在950hz。
为此，考虑将这些传感器读取的工作移出vehicle线程，在low_freq_sensors任务中按照对应频率更新。此时vehicle线程可以稳定原先的1000hz。对总体CPU占用率几乎没有影响。

对比：调整前
<img width="952" height="1232" alt="image" src="https://github.com/user-attachments/assets/3b5bc15b-2162-4f3c-965a-593563135e62" />
调整后：
<img width="992" height="1253" alt="e7290f3f1a852de831ef27f967300514" src="https://github.com/user-attachments/assets/95c7dab2-73f1-4740-8e37-10c5715d1bff" />
